### PR TITLE
Fixes duplicate Security Group error

### DIFF
--- a/modules/baseline/host-bastion.tf
+++ b/modules/baseline/host-bastion.tf
@@ -11,14 +11,7 @@ module "sg_bastion_host" {
       to_port     = local.rdp_port
       protocol    = local.tcp_protocol
       description = "Remote desktop connections from the public Internet"
-      cidr_blocks = var.trusted_cidr
-    },
-    {
-      from_port   = local.rdp_port
-      to_port     = local.rdp_port
-      protocol    = local.tcp_protocol
-      description = "Remote desktop connections from the public Internet"
-      cidr_blocks = local.trusted_cidr_local
+      cidr_blocks = "${var.trusted_cidr},${local.trusted_cidr_local}"
     },
 
     # Issuing CA

--- a/modules/baseline_preprod/host-bastion.tf
+++ b/modules/baseline_preprod/host-bastion.tf
@@ -11,14 +11,7 @@ module "sg_bastion_host" {
       to_port     = local.rdp_port
       protocol    = local.tcp_protocol
       description = "Remote desktop connections from the public Internet"
-      cidr_blocks = var.trusted_cidr
-    },
-    {
-      from_port   = local.rdp_port
-      to_port     = local.rdp_port
-      protocol    = local.tcp_protocol
-      description = "Remote desktop connections from the public Internet"
-      cidr_blocks = local.trusted_cidr_local
+      cidr_blocks = "${var.trusted_cidr},${local.trusted_cidr_local}"
     },
 
     # Issuing CA


### PR DESCRIPTION
introduced by previous change.
This value eventually is a list in the SG module but the list needs to be passed in as a comma separated string value.