### PR TITLE
Add alarms to instances

### DIFF
--- a/modules/alarms/main.tf
+++ b/modules/alarms/main.tf
@@ -1,0 +1,18 @@
+module "metric_alarm" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+  version = "~> 3.0"
+
+  alarm_name          = var.alarm_name
+  alarm_description   = var.alarm_description
+  comparison_operator = var.comparison_operator
+  evaluation_periods  = var.evaluation_periods
+  threshold           = var.threshold
+  period              = var.period
+  unit                = var.unit
+
+  namespace   = "${var.prefix}-pki-service"
+  metric_name = var.metric_name
+  statistic   = var.statistic
+
+  alarm_actions = var.alarm_actions
+}

--- a/modules/alarms/main.tf
+++ b/modules/alarms/main.tf
@@ -10,7 +10,7 @@ module "metric_alarm" {
   period              = var.period
   unit                = var.unit
 
-  namespace   = "${var.prefix}-pki-service"
+  namespace   = var.namespace
   metric_name = var.metric_name
   statistic   = var.statistic
 

--- a/modules/alarms/outputs.tf
+++ b/modules/alarms/outputs.tf
@@ -1,0 +1,3 @@
+output "alarm_name" {
+  value = module.metric_alarm.alarm_name
+}

--- a/modules/alarms/outputs.tf
+++ b/modules/alarms/outputs.tf
@@ -1,3 +1,0 @@
-output "alarm_name" {
-  value = module.metric_alarm.alarm_name
-}

--- a/modules/alarms/variables.tf
+++ b/modules/alarms/variables.tf
@@ -3,6 +3,11 @@ variable "alarm_name" {
   type        = string
 }
 
+variable "namespace" {
+  description = "The namespace for the alarm's associated metric."
+  type        = string
+}
+
 variable "alarm_description" {
   description = "Description of the alarm"
   type        = string

--- a/modules/alarms/variables.tf
+++ b/modules/alarms/variables.tf
@@ -1,0 +1,50 @@
+variable "alarm_name" {
+  description = "The name for the alarm that will appear in the EC2 console"
+  type        = string
+}
+
+variable "alarm_description" {
+  description = "Description of the alarm"
+  type        = string
+}
+
+variable "comparison_operator" {
+  description = "The arithmetic operation to use when comparing the specified Statistic and Threshold."
+  type        = string
+}
+
+variable "evaluation_periods" {
+  description = "The number of periods over which data is compared to the specified threshold."
+  type        = number
+}
+
+variable "threshold" {
+  description = "The value against which the specified statistic is compared."
+  type        = number
+}
+
+variable "period" {
+  description = "The period in seconds over which the specified statistic is applied. Valid values are 10, 30, or any multiple of 60."
+  type        = number
+}
+
+variable "unit" {
+  description = " The unit for the alarm's associated metric."
+  type        = string
+}
+
+variable "metric_name" {
+  description = "The name for the alarm's associated metric."
+  type        = string
+}
+
+variable "statistic" {
+  description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum."
+  type        = string
+}
+
+variable "alarm_actions" {
+  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state."
+  type        = list(string)
+  default     = null
+}

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -196,7 +196,7 @@ module "ec2_ca_gateway" {
 }
 
 module "metric_alarm" {  
-  source = ".././metric_alarm"
+  source = ".././alarms"
 
   alarm_name  = "${var.prefix}-status-check-ca-gateway"
   alarm_description = "Check for instance status check errors."

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -195,7 +195,7 @@ module "ec2_ca_gateway" {
   )
 }
 
-module "metric_alarm" {
+module "ma_system_status_check" {
   source = ".././alarms"
 
   alarm_name          = "${var.prefix}-system-status-check-ca-gateway"
@@ -211,7 +211,7 @@ module "metric_alarm" {
   statistic   = "Maximum"
 }
 
-module "metric_alarm" {
+module "ma_instance_status_check" {
   source = ".././alarms"
 
   alarm_name          = "${var.prefix}-instance-status-check-ca-gateway"

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -198,7 +198,7 @@ module "ec2_ca_gateway" {
 module "metric_alarm" {
   source = ".././alarms"
 
-  alarm_name          = "${var.prefix}-status-check-ca-gateway"
+  alarm_name          = "${var.prefix}-system-status-check-ca-gateway"
   namespace           = "${var.prefix}-ca-gateway"
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -208,5 +208,21 @@ module "metric_alarm" {
   unit                = "Count"
 
   metric_name = "StatusCheckFailed_System"
+  statistic   = "Maximum"
+}
+
+module "metric_alarm" {
+  source = ".././alarms"
+
+  alarm_name          = "${var.prefix}-instance-status-check-ca-gateway"
+  namespace           = "${var.prefix}-ca-gateway"
+  alarm_description   = "Check for instance status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_Instance"
   statistic   = "Maximum"
 }

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -194,3 +194,18 @@ module "ec2_ca_gateway" {
     },
   )
 }
+
+module "metric_alarm" {  
+  source = ".././metric_alarm"
+
+  alarm_name  = "${var.prefix}-status-check-ca-gateway"
+  alarm_description = "Check for instance status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods = 1
+  threshold = 1
+  period = 60
+  unit = "Count"
+
+  metric_name = "StatusCheckFailed_System"
+  statistic = "Maximum"
+}

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -196,7 +196,7 @@ module "ec2_ca_gateway" {
 }
 
 module "metric_alarm" {
-  source = ".././metric_alarm"
+  source = ".././alarms"
 
   alarm_name          = "${var.prefix}-status-check-ca-gateway"
   alarm_description   = "Check for instance status check errors."

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -199,6 +199,7 @@ module "metric_alarm" {
   source = ".././alarms"
 
   alarm_name          = "${var.prefix}-status-check-ca-gateway"
+  namespace           = "${var.prefix}-ca-gateway"
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1


### PR DESCRIPTION
Adds 2 test alarms to the pre-production ca-gateway EC2 instance.

This PR is just to test that the code for adding alarms works.

* System Status Alarm
* Instance Status Alarm