### PR TITLE
Adds CPU and Network alarms

### DIFF
--- a/modules/alarms/main.tf
+++ b/modules/alarms/main.tf
@@ -15,4 +15,8 @@ module "metric_alarm" {
   statistic   = var.statistic
 
   alarm_actions = var.alarm_actions
+
+  dimensions = {
+    InstanceId = var.instance_id
+  }
 }

--- a/modules/alarms/variables.tf
+++ b/modules/alarms/variables.tf
@@ -53,3 +53,9 @@ variable "alarm_actions" {
   type        = list(string)
   default     = null
 }
+
+variable "instance_id" {
+  description = "EC2 instance ID to attach the alarm/metric too."
+  type        = string
+  default     = null
+}

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -209,6 +209,8 @@ module "ma_system_status_check" {
 
   metric_name = "StatusCheckFailed_System"
   statistic   = "Maximum"
+
+  instance_id = module.ec2_ca_gateway.instance_id[0]
 }
 
 module "ma_instance_status_check" {
@@ -225,6 +227,8 @@ module "ma_instance_status_check" {
 
   metric_name = "StatusCheckFailed_Instance"
   statistic   = "Maximum"
+
+  instance_id = module.ec2_ca_gateway.instance_id[0]
 }
 
 module "ma_cpu_utilization_status_check" {
@@ -241,6 +245,8 @@ module "ma_cpu_utilization_status_check" {
 
   metric_name = "CPUUtilization"
   statistic   = "Average"
+
+  instance_id = module.ec2_ca_gateway.instance_id[0]
 }
 
 module "ma_network_packets_in_status_check" {
@@ -257,4 +263,6 @@ module "ma_network_packets_in_status_check" {
 
   metric_name = "NetworkPacketsIn"
   statistic   = "Average"
+
+  instance_id = module.ec2_ca_gateway.instance_id[0]
 }

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -198,9 +198,9 @@ module "ec2_ca_gateway" {
 module "ma_system_status_check" {
   source = ".././alarms"
 
-  alarm_name          = "${var.prefix}-system-status-check-ca-gateway"
+  alarm_name          = "${var.prefix}-system-status-check-ca-gateway-alarm"
   namespace           = "${var.prefix}-ca-gateway"
-  alarm_description   = "Check for instance status check errors."
+  alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
   threshold           = 1
@@ -214,7 +214,7 @@ module "ma_system_status_check" {
 module "ma_instance_status_check" {
   source = ".././alarms"
 
-  alarm_name          = "${var.prefix}-instance-status-check-ca-gateway"
+  alarm_name          = "${var.prefix}-instance-status-check-ca-gateway-alarm"
   namespace           = "${var.prefix}-ca-gateway"
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -225,4 +225,36 @@ module "ma_instance_status_check" {
 
   metric_name = "StatusCheckFailed_Instance"
   statistic   = "Maximum"
+}
+
+module "ma_cpu_utilization_status_check" {
+  source = ".././alarms"
+
+  alarm_name          = "${var.prefix}-cpu-utilization-ca-gateway-alarm"
+  namespace           = "${var.prefix}-ca-gateway"
+  alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 15
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "CPUUtilization"
+  statistic   = "Average"
+}
+
+module "ma_network_packets_in_status_check" {
+  source = ".././alarms"
+
+  alarm_name          = "${var.prefix}-network-packets-in-ca-gateway-alarm"
+  namespace           = "${var.prefix}-ca-gateway"
+  alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 1500
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "NetworkPacketsIn"
+  statistic   = "Average"
 }


### PR DESCRIPTION
Adds additional alarms for CPU utilisation and Networking Packets.

Assigns 4 alarms to pre-prod CA Gateway EC2 instances causing replacement (destroy) of 2 existing alarms as names have changed.