### PR TITLE
Change alarm namespace to AWS/EC2

### DIFF
--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -199,7 +199,7 @@ module "ma_system_status_check" {
   source = ".././alarms"
 
   alarm_name          = "${var.prefix}-system-status-check-ca-gateway-alarm"
-  namespace           = "${var.prefix}-ca-gateway"
+  namespace           = "AWS/EC2"
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
@@ -217,7 +217,7 @@ module "ma_instance_status_check" {
   source = ".././alarms"
 
   alarm_name          = "${var.prefix}-instance-status-check-ca-gateway-alarm"
-  namespace           = "${var.prefix}-ca-gateway"
+  namespace           = "AWS/EC2"
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
@@ -235,7 +235,7 @@ module "ma_cpu_utilization_status_check" {
   source = ".././alarms"
 
   alarm_name          = "${var.prefix}-cpu-utilization-ca-gateway-alarm"
-  namespace           = "${var.prefix}-ca-gateway"
+  namespace           = "AWS/EC2"
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
@@ -253,7 +253,7 @@ module "ma_network_packets_in_status_check" {
   source = ".././alarms"
 
   alarm_name          = "${var.prefix}-network-packets-in-ca-gateway-alarm"
-  namespace           = "${var.prefix}-ca-gateway"
+  namespace           = "AWS/EC2"
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2


### PR DESCRIPTION
Potential fix for alarms not reading data from EC2 instances.