### PR TITLE
Adds SNS and Lambda integration to send message to MS Teams channel on EC2 Alarm

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -6,7 +6,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/code-formatter@main
+      - uses: actions/checkout@v3
+      - uses: ministryofjustice/github-actions/code-formatter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -63,6 +63,7 @@ jobs:
           TF_VAR_ASSUME_ROLE, staff-infrastructure-certificate-services/production/assume_role_arn
           TF_VAR_CGW_HSM_PRIMARY_IP, staff-infrastructure-certificate-services/production/cgw_hsm_primary_ip
           TF_VAR_CGW_HSM_SECONDARY_IP, staff-infrastructure-certificate-services/production/cgw_hsm_secondary_ip
+          TF_VAR_MS_TEAMS_WEBHOOK_URL, staff-infrastructure-certificate-services/production/ms_teams_webhook_url
 
     # aws-secretsmanager-get-secrets will not assign to mixed case env var so this work around is necessary
     - name: Assign Uppercase secrets env vars to mixed case env vars
@@ -83,6 +84,7 @@ jobs:
         echo "TF_VAR_assume_role=${TF_VAR_ASSUME_ROLE}" >> $GITHUB_ENV
         echo "TF_VAR_cgw_hsm_primary_ip=${TF_VAR_CGW_HSM_PRIMARY_IP}" >> $GITHUB_ENV
         echo "TF_VAR_cgw_hsm_secondary_ip=${TF_VAR_CGW_HSM_SECONDARY_IP}" >> $GITHUB_ENV
+        echo "TF_VAR_ms_teams_webhook_url=${TF_VAR_MS_TEAMS_WEBHOOK_URL}" >> $GITHUB_ENV
 
     # Install the latest version of Terraform CLI
     - name: Setup Terraform

--- a/adaptiveCard/schema.json
+++ b/adaptiveCard/schema.json
@@ -1,0 +1,79 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.4",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "MoJ PKI Service Alarm",
+      "wrap": true,
+      "spacing": "ExtraLarge",
+      "fontType": "Default",
+      "size": "Medium",
+      "weight": "Bolder",
+      "color": "Attention"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Alarm Description",
+              "wrap": true,
+              "weight": "Bolder",
+              "color": "Accent"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Alarm Link",
+              "wrap": true,
+              "color": "Accent",
+              "weight": "Bolder"
+            }
+          ]
+        }
+      ],
+      "spacing": "Small",
+      "separator": true,
+      "horizontalAlignment": "Center"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "@{triggerBody()?['Title']}",
+              "wrap": true
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "horizontalAlignment": "right",
+              "text": "View alarm [@{triggerBody()?['potentialAction']?[0]?['targets'][0]['uri']}](@{triggerBody()?['potentialAction']?[0]?['targets'][0]['uri']}) ",
+              "wrap": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -1,0 +1,58 @@
+import json   # Importing json library for parsing JSON data
+import requests   # Importing requests library for sending HTTP requests
+import os   # Importing os library for accessing environment variables
+
+
+def lambda_handler(event, context):
+    # Accessing the message from the SNS event passed as input to the Lambda function
+    message = event['Records'][0]['Sns']['Message']
+
+    # Parsing the JSON message to extract various details about the CloudWatch alarm triggered
+    message = event['Records'][0]['Sns']['Message']
+    alarm_name = json.loads(message)['AlarmName']
+    alarm_desc = json.loads(message)['AlarmDescription']
+    new_state = json.loads(message)['NewStateValue']
+    alarm_time = json.loads(message)['StateChangeTime']
+    instance_id = json.loads(message)['Trigger']['Dimensions'][0]['value']
+    region = json.loads(message)['Region']
+    account_id = context.invoked_function_arn.split(':')[4]
+
+    # Create url link to view alarm
+    alarm_url = f"https://console.aws.amazon.com/cloudwatch/home?region={region}#s=Alarms&alarm={alarm_name}"
+
+    # Setting the theme color for the Teams message based on the new state of the alarm
+    if new_state == "ALARM":
+        colour = "FF0000"
+    elif new_state == "OK":
+        colour = "00FF00"
+    else:
+        colour = "0000FF"
+
+    # Constructing the Teams message payload for an alarm
+    message_card = {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "themeColor": colour,
+        "title": f"{alarm_name} {new_state} on {instance_id}",
+        "text": f"Alarm description: {alarm_desc}\nCurrent state: {new_state}\nTriggered time: {alarm_time}",
+        "potentialAction": [
+            {
+                "@type": "OpenUri",
+                "name": "View Alarm",
+                "targets": [
+                    {
+                        "os": "default",
+                        "uri": alarm_url
+                    }
+                ]
+            }
+        ]
+    }
+
+    # Sending the Teams message to the specified webhook URL
+    webhook_url = os.environ['TEAMS_WEBHOOK_URL']
+    headers = {
+        'Content-Type': 'application/json'
+    }
+    response = requests.post(webhook_url, json=message_card, headers=headers)
+    print(response.text)

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -50,7 +50,7 @@ def lambda_handler(event, context):
     }
 
     # Sending the Teams message to the specified webhook URL
-    webhook_url = os.environ['TEAMS_WEBHOOK_URL']
+    webhook_url = os.environ['MS_TEAMS_WEBHOOK_URL']
     headers = {
         'Content-Type': 'application/json'
     }

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,8 @@ module "baseline_pre_production" {
   gp_client_prod_cidr_block = var.gp_client_prod_cidr_block
   alz_cidr_block            = var.alz_cidr_block
 
+  ms_teams_webhook_url = var.ms_teams_webhook_url
+
   providers = {
     aws = aws.env
   }

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -211,6 +211,8 @@ module "ma_system_status_check" {
   statistic   = "Maximum"
 
   instance_id = module.ec2_ca_gateway.instance_id[0]
+
+  alarm_actions = [module.sns_topic.sns_topic_arn]
 }
 
 module "ma_instance_status_check" {
@@ -229,6 +231,8 @@ module "ma_instance_status_check" {
   statistic   = "Maximum"
 
   instance_id = module.ec2_ca_gateway.instance_id[0]
+
+  alarm_actions = [module.sns_topic.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check" {
@@ -247,6 +251,8 @@ module "ma_cpu_utilization_status_check" {
   statistic   = "Average"
 
   instance_id = module.ec2_ca_gateway.instance_id[0]
+
+  alarm_actions = [module.sns_topic.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check" {
@@ -265,4 +271,6 @@ module "ma_network_packets_in_status_check" {
   statistic   = "Average"
 
   instance_id = module.ec2_ca_gateway.instance_id[0]
+
+  alarm_actions = [module.sns_topic.sns_topic_arn]
 }

--- a/modules/baseline_preprod/main.tf
+++ b/modules/baseline_preprod/main.tf
@@ -72,3 +72,27 @@ module "tgw-attach" {
 
   prefix = var.prefix
 }
+
+module "sns_topic" {
+  source = ".././sns"
+
+  name              = "ec2-alarm-sns"
+  teams_webhook_url = "https://tempurl"
+}
+
+module "teams_lambda" {
+  source = ".././lambda"
+
+  source_file = "lambda/lambda_function.py"
+  output_path = "lambda/lambda_function.zip"
+
+  function_name        = "ms-teams-sns-notification"
+  description          = "Send alarms from EC2 instances to MS Teams channel"
+  ms_teams_webhook_url = var.ms_teams_webhook_url
+}
+
+resource "aws_sns_topic_subscription" "teams_notifications_subscription" {
+  topic_arn = module.sns_topic.sns_topic_arn
+  protocol  = "https"
+  endpoint  = module.teams_lambda.lambda_function_arn
+}

--- a/modules/baseline_preprod/main.tf
+++ b/modules/baseline_preprod/main.tf
@@ -76,7 +76,7 @@ module "tgw-attach" {
 module "sns_topic" {
   source = ".././sns"
 
-  name              = "ec2-alarm-sns"
+  name                 = "ec2-alarm-sns"
   ms_teams_webhook_url = "https://tempurl"
 }
 

--- a/modules/baseline_preprod/main.tf
+++ b/modules/baseline_preprod/main.tf
@@ -77,7 +77,7 @@ module "sns_topic" {
   source = ".././sns"
 
   name              = "ec2-alarm-sns"
-  teams_webhook_url = "https://tempurl"
+  ms_teams_webhook_url = "https://tempurl"
 }
 
 module "teams_lambda" {

--- a/modules/baseline_preprod/variables.tf
+++ b/modules/baseline_preprod/variables.tf
@@ -61,3 +61,7 @@ variable "gp_client_prod_cidr_block" {
 variable "alz_cidr_block" {
   type = string
 }
+
+variable "ms_teams_webhook_url" {
+  type = string
+}

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -1,0 +1,23 @@
+data "archive_file" "teams_lambda_file" {
+  type        = "zip"
+  source_file = var.source_file
+  output_path = var.output_path
+}
+
+module "teams_lambda_function" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 3.0"
+
+  function_name = var.function_name
+  description   = var.description
+  handler       = "index.lambda_handler"
+  runtime       = "python3.9"
+
+  create_package         = false
+  local_existing_package = var.output_path
+
+  # Set environment variables for the Lambda function
+  environment_variables = {
+    MS_TEAMS_WEBHOOK_URL = var.ms_teams_webhook_url
+  }
+}

--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -1,0 +1,3 @@
+output "lambda_function_arn" {
+  value = module.teams_lambda_function.lambda_function_arn
+}

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -1,0 +1,24 @@
+variable "function_name" {
+  description = "Name of the Lambda function."
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the lambda."
+  type        = string
+}
+
+variable "source_file" {
+  description = "Location of the lambda function."
+  type        = string
+}
+
+variable "output_path" {
+  description = "Output destination for the zipped lambda function."
+  type        = string
+}
+
+variable "ms_teams_webhook_url" {
+  description = "MS Teams webhook URL to send alarm to."
+  type        = string
+}

--- a/modules/sns/main.tf
+++ b/modules/sns/main.tf
@@ -1,0 +1,6 @@
+module "sns" {
+  source  = "terraform-aws-modules/sns/aws"
+  version = "~> 3.0"
+
+  name = var.name
+}

--- a/modules/sns/outputs.tf
+++ b/modules/sns/outputs.tf
@@ -1,0 +1,3 @@
+output "sns_topic_arn" {
+  value = module.sns.sns_topic_arn
+}

--- a/modules/sns/variables.tf
+++ b/modules/sns/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
   type        = string
 }
 
-variable "teams_webhook_url" {
+variable "ms_teams_webhook_url" {
   description = "The MS Teams Channel Webhook url to send the message card too."
   type        = string
 }

--- a/modules/sns/variables.tf
+++ b/modules/sns/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  description = "The name for the SNS Topic."
+  type        = string
+}
+
+variable "teams_webhook_url" {
+  description = "The MS Teams Channel Webhook url to send the message card too."
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,7 @@ variable "mojo_production_account_id" {
 variable "alz_cidr_block" {
   type = string
 }
+
+variable "ms_teams_webhook_url" {
+  type = string
+}


### PR DESCRIPTION
Adds the following resources

* New Python Lambda code to process SNS message and send to MS Teams
* Auto zip Python code
* Lambda and SNS resource
* Connect SNS resource to EC2 Alarms as actions
* Updated code formatter GH Action to fix bug with formatting python code.