### PR TITLE
Change protocol for sns topic subscription to lambda

### DIFF
--- a/modules/baseline_preprod/main.tf
+++ b/modules/baseline_preprod/main.tf
@@ -93,6 +93,6 @@ module "teams_lambda" {
 
 resource "aws_sns_topic_subscription" "teams_notifications_subscription" {
   topic_arn = module.sns_topic.sns_topic_arn
-  protocol  = "https"
+  protocol  = "lambda"
   endpoint  = module.teams_lambda.lambda_function_arn
 }


### PR DESCRIPTION
Error on last apply below where protocol was set to https instead of lambda. This update changes the protocol.
```
Error: creating SNS Topic Subscription: InvalidParameter: Invalid parameter: Endpoint must match the specified protocol
│ 	status code: 400, request id: d03625f9-c999-5879-a8dd-7a2a49ce7bd9
│ 
│   with module.baseline_pre_production.aws_sns_topic_subscription.teams_notifications_subscription,
│   on modules/baseline_preprod/main.tf line 94, in resource "aws_sns_topic_subscription" "teams_notifications_subscription":
│   94: resource "aws_sns_topic_subscription" "teams_notifications_subscription" {
```