### PR TITLE
Add Production Alarms to EC2 instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,3 +128,27 @@ module "lambda_stop_start" {
     aws = aws.env
   }
 }
+
+module "sns_topic" {
+  source = ".././sns"
+
+  name                 = "ec2-alarm-sns"
+  ms_teams_webhook_url = var.ms_teams_webhook_url
+}
+
+module "teams_lambda" {
+  source = ".././lambda"
+
+  source_dir  = "lambda"
+  output_path = "lambda/lambda_function.zip"
+
+  function_name        = "ms-teams-sns-notification"
+  description          = "Send alarms from EC2 instances to MS Teams channel"
+  ms_teams_webhook_url = var.ms_teams_webhook_url
+}
+
+resource "aws_sns_topic_subscription" "teams_notifications_subscription" {
+  topic_arn = module.sns_topic.sns_topic_arn
+  protocol  = "lambda"
+  endpoint  = module.teams_lambda.lambda_function_arn
+}

--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,7 @@ module "baseline_pre_production" {
   alz_cidr_block            = var.alz_cidr_block
 
   ms_teams_webhook_url = var.ms_teams_webhook_url
+  sns_topic_arn        = module.sns_topic.sns_topic_arn
 
   providers = {
     aws = aws.env
@@ -139,6 +140,9 @@ module "baseline_production" {
   mojo_prod_tgw_id          = var.mojo_prod_tgw_id
   gp_client_prod_cidr_block = var.gp_client_prod_cidr_block
   alz_cidr_block            = var.alz_cidr_block
+
+  ms_teams_webhook_url = var.ms_teams_webhook_url
+  sns_topic_arn        = module.sns_topic.sns_topic_arn
 
   providers = {
     aws = aws.env

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,30 @@ module "iam" {
   }
 }
 
+module "sns_topic" {
+  source = "./modules/sns"
+
+  name                 = "ec2-alarm-sns"
+  ms_teams_webhook_url = var.ms_teams_webhook_url
+}
+
+module "teams_lambda" {
+  source = "./modules/lambda"
+
+  source_dir  = "lambda"
+  output_path = "lambda/lambda_function.zip"
+
+  function_name        = "ms-teams-sns-notification"
+  description          = "Send alarms from EC2 instances to MS Teams channel"
+  ms_teams_webhook_url = var.ms_teams_webhook_url
+}
+
+resource "aws_sns_topic_subscription" "teams_notifications_subscription" {
+  topic_arn = module.sns_topic.sns_topic_arn
+  protocol  = "lambda"
+  endpoint  = module.teams_lambda.lambda_function_arn
+}
+
 module "baseline_pre_production" {
   source = "./modules/baseline_preprod"
 
@@ -127,28 +151,4 @@ module "lambda_stop_start" {
   providers = {
     aws = aws.env
   }
-}
-
-module "sns_topic" {
-  source = "./modules/sns"
-
-  name                 = "ec2-alarm-sns"
-  ms_teams_webhook_url = var.ms_teams_webhook_url
-}
-
-module "teams_lambda" {
-  source = "./modules/lambda"
-
-  source_dir  = "lambda"
-  output_path = "lambda/lambda_function.zip"
-
-  function_name        = "ms-teams-sns-notification"
-  description          = "Send alarms from EC2 instances to MS Teams channel"
-  ms_teams_webhook_url = var.ms_teams_webhook_url
-}
-
-resource "aws_sns_topic_subscription" "teams_notifications_subscription" {
-  topic_arn = module.sns_topic.sns_topic_arn
-  protocol  = "lambda"
-  endpoint  = module.teams_lambda.lambda_function_arn
 }

--- a/main.tf
+++ b/main.tf
@@ -130,14 +130,14 @@ module "lambda_stop_start" {
 }
 
 module "sns_topic" {
-  source = ".././sns"
+  source = "./modules/sns"
 
   name                 = "ec2-alarm-sns"
   ms_teams_webhook_url = var.ms_teams_webhook_url
 }
 
 module "teams_lambda" {
-  source = ".././lambda"
+  source = "./modules/lambda"
 
   source_dir  = "lambda"
   output_path = "lambda/lambda_function.zip"

--- a/modules/baseline/host-ca-gateway.tf
+++ b/modules/baseline/host-ca-gateway.tf
@@ -208,7 +208,7 @@ module "ma_system_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_ca_gateway" {
@@ -226,7 +226,7 @@ module "ma_instance_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_ca_gateway" {
@@ -244,7 +244,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_ca_gateway" {
@@ -262,5 +262,5 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline/host-ca-gateway.tf
+++ b/modules/baseline/host-ca-gateway.tf
@@ -192,3 +192,75 @@ module "ec2_ca_gateway" {
     },
   )
 }
+
+module "ma_system_status_check_ca_gateway" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-system-status-check-ca-gateway-alarm"
+  alarm_description   = "Check for system status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_System"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_ca_gateway.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_instance_status_check_ca_gateway" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-instance-status-check-ca-gateway-alarm"
+  alarm_description   = "Check for instance status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_Instance"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_ca_gateway.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_cpu_utilization_status_check_ca_gateway" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-cpu-utilization-ca-gateway-alarm"
+  alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 15
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "CPUUtilization"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_ca_gateway.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_network_packets_in_status_check_ca_gateway" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-network-packets-in-ca-gateway-alarm"
+  alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 1500
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "NetworkPacketsIn"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_ca_gateway.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}

--- a/modules/baseline/host-issuing-ca.tf
+++ b/modules/baseline/host-issuing-ca.tf
@@ -380,7 +380,7 @@ module "ma_system_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_issuing_ca" {
@@ -398,7 +398,7 @@ module "ma_instance_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_issuing_ca" {
@@ -416,7 +416,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_issuing_ca" {
@@ -434,5 +434,5 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline/host-issuing-ca.tf
+++ b/modules/baseline/host-issuing-ca.tf
@@ -364,3 +364,75 @@ resource "aws_volume_attachment" "issuing_CA_tertiary_ebs_attach" {
   volume_id   = aws_ebs_volume.issuing_CA_tertiary_ebs.id
   instance_id = module.ec2_issuing_ca.instance_id[0]
 }
+
+module "ma_system_status_check_issuing_ca" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-system-status-check-issuing-ca-alarm"
+  alarm_description   = "Check for system status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_System"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_issuing_ca.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_instance_status_check_issuing_ca" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-instance-status-check-issuing-ca-alarm"
+  alarm_description   = "Check for instance status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_Instance"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_issuing_ca.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_cpu_utilization_status_check_issuing_ca" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-cpu-utilization-issuing-ca-alarm"
+  alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 20
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "CPUUtilization"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_issuing_ca.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_network_packets_in_status_check_issuing_ca" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-network-packets-in-issuing-ca-alarm"
+  alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 2500
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "NetworkPacketsIn"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_issuing_ca.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}

--- a/modules/baseline/host-ra-app-server.tf
+++ b/modules/baseline/host-ra-app-server.tf
@@ -229,3 +229,75 @@ module "ec2_ra_app_server" {
     },
   )
 }
+
+module "ma_system_status_check_ra_app_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-system-status-check-ra-app-server-alarm"
+  alarm_description   = "Check for system status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_System"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_ra_app_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_instance_status_check_ra_app_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-instance-status-check-ra-app-server-alarm"
+  alarm_description   = "Check for instance status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_Instance"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_ra_app_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_cpu_utilization_status_check_ra_app_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-cpu-utilization-ra-app-server-alarm"
+  alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 18
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "CPUUtilization"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_ra_app_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_network_packets_in_status_check_ra_app_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-network-packets-in-ra-app-server-alarm"
+  alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 3500
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "NetworkPacketsIn"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_ra_app_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}

--- a/modules/baseline/host-ra-app-server.tf
+++ b/modules/baseline/host-ra-app-server.tf
@@ -245,7 +245,7 @@ module "ma_system_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_ra_app_server" {
@@ -263,7 +263,7 @@ module "ma_instance_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_ra_app_server" {
@@ -281,7 +281,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_ra_app_server" {
@@ -299,5 +299,5 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline/host-ra-web-server.tf
+++ b/modules/baseline/host-ra-web-server.tf
@@ -192,3 +192,75 @@ module "ec2_ra_web_server" {
     },
   )
 }
+
+module "ma_system_status_check_ra_web_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-system-status-check-ra-web-server-alarm"
+  alarm_description   = "Check for system status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_System"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_ra_web_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_instance_status_check_ra_web_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-instance-status-check-ra-web-server-alarm"
+  alarm_description   = "Check for instance status check errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  metric_name = "StatusCheckFailed_Instance"
+  statistic   = "Maximum"
+
+  instance_id   = module.ec2_ra_web_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_cpu_utilization_status_check_ra_web_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-cpu-utilization-ra-web-server-alarm"
+  alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 1
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "CPUUtilization"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_ra_web_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+module "ma_network_packets_in_status_check_ra_web_server" {
+  source = ".././ec2alarms"
+
+  alarm_name          = "${var.prefix}-network-packets-in-ra-web-server-alarm"
+  alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  threshold           = 3000
+  period              = 300 # 5 minutes
+  unit                = "Count"
+
+  metric_name = "NetworkPacketsIn"
+  statistic   = "Average"
+
+  instance_id   = module.ec2_ra_web_server.instance_id[0]
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}

--- a/modules/baseline/host-ra-web-server.tf
+++ b/modules/baseline/host-ra-web-server.tf
@@ -208,7 +208,7 @@ module "ma_system_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_ra_web_server" {
@@ -226,7 +226,7 @@ module "ma_instance_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_ra_web_server" {
@@ -244,7 +244,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_ra_web_server" {
@@ -262,5 +262,5 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline/main.tf
+++ b/modules/baseline/main.tf
@@ -57,7 +57,7 @@ module "vpn_production" {
   secondary_remote_destination_cidr = var.secondary_remote_destination_cidr
   seondary_internal_cidr            = var.seondary_internal_cidr
 
-  sns_topic_arn                     = module.sns_topic.sns_topic_arn
+  sns_topic_arn = module.sns_topic.sns_topic_arn
 
   cgw_hsm_primary_id   = var.cgw_hsm_primary_id
   cgw_hsm_secondary_id = var.cgw_hsm_secondary_id

--- a/modules/baseline/main.tf
+++ b/modules/baseline/main.tf
@@ -57,6 +57,8 @@ module "vpn_production" {
   secondary_remote_destination_cidr = var.secondary_remote_destination_cidr
   seondary_internal_cidr            = var.seondary_internal_cidr
 
+  sns_topic_arn                     = module.sns_topic.sns_topic_arn
+
   cgw_hsm_primary_id   = var.cgw_hsm_primary_id
   cgw_hsm_secondary_id = var.cgw_hsm_secondary_id
 

--- a/modules/baseline/main.tf
+++ b/modules/baseline/main.tf
@@ -57,8 +57,6 @@ module "vpn_production" {
   secondary_remote_destination_cidr = var.secondary_remote_destination_cidr
   seondary_internal_cidr            = var.seondary_internal_cidr
 
-  sns_topic_arn = module.sns_topic.sns_topic_arn
-
   cgw_hsm_primary_id   = var.cgw_hsm_primary_id
   cgw_hsm_secondary_id = var.cgw_hsm_secondary_id
 

--- a/modules/baseline/variables.tf
+++ b/modules/baseline/variables.tf
@@ -61,3 +61,11 @@ variable "gp_client_prod_cidr_block" {
 variable "alz_cidr_block" {
   type = string
 }
+
+variable "ms_teams_webhook_url" {
+  type = string
+}
+
+variable "sns_topic_arn" {
+  type = string
+}

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -210,7 +210,7 @@ module "ma_system_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_ca_gateway" {
@@ -228,7 +228,7 @@ module "ma_instance_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_ca_gateway" {
@@ -246,7 +246,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_ca_gateway" {
@@ -264,5 +264,5 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -382,7 +382,7 @@ module "ma_system_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_issuing_ca" {
@@ -400,7 +400,7 @@ module "ma_instance_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_issuing_ca" {
@@ -418,7 +418,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_issuing_ca" {
@@ -436,5 +436,5 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline_preprod/host-ra-app-server.tf
+++ b/modules/baseline_preprod/host-ra-app-server.tf
@@ -247,7 +247,7 @@ module "ma_system_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_ra_app_server" {
@@ -265,7 +265,7 @@ module "ma_instance_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_ra_app_server" {
@@ -283,7 +283,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_ra_app_server" {
@@ -301,5 +301,5 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline_preprod/host-ra-web-server.tf
+++ b/modules/baseline_preprod/host-ra-web-server.tf
@@ -210,7 +210,7 @@ module "ma_system_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_instance_status_check_ra_web_server" {
@@ -228,7 +228,7 @@ module "ma_instance_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_cpu_utilization_status_check_ra_web_server" {
@@ -246,7 +246,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }
 
 module "ma_network_packets_in_status_check_ra_web_server" {
@@ -264,5 +264,5 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  alarm_actions = [var.sns_topic_arn]
 }

--- a/modules/baseline_preprod/main.tf
+++ b/modules/baseline_preprod/main.tf
@@ -72,27 +72,3 @@ module "tgw-attach" {
 
   prefix = var.prefix
 }
-
-module "sns_topic" {
-  source = ".././sns"
-
-  name                 = "ec2-alarm-sns"
-  ms_teams_webhook_url = var.ms_teams_webhook_url
-}
-
-module "teams_lambda" {
-  source = ".././lambda"
-
-  source_dir  = "lambda"
-  output_path = "lambda/lambda_function.zip"
-
-  function_name        = "ms-teams-sns-notification"
-  description          = "Send alarms from EC2 instances to MS Teams channel"
-  ms_teams_webhook_url = var.ms_teams_webhook_url
-}
-
-resource "aws_sns_topic_subscription" "teams_notifications_subscription" {
-  topic_arn = module.sns_topic.sns_topic_arn
-  protocol  = "lambda"
-  endpoint  = module.teams_lambda.lambda_function_arn
-}

--- a/modules/baseline_preprod/variables.tf
+++ b/modules/baseline_preprod/variables.tf
@@ -65,3 +65,7 @@ variable "alz_cidr_block" {
 variable "ms_teams_webhook_url" {
   type = string
 }
+
+variable "sns_topic_arn" {
+  type = string
+}


### PR DESCRIPTION
* Moves Lambda and SNS Topic code to root main.tf to be a shared resource across both prod and pre-prod
* Update pre-prod alarms to point to new SNS location
* Add alarms to production EC2 instances.

Because lambda and SNS is moved to root main.tf they will need to be destroyed and re-created as shown in Terraform Plan.

CHG0090154 scheduled for 13-01-2025 11:45:00