### PR TITLE
Align Terraform to EC2 Alarms in AWS

### DIFF
--- a/modules/baseline/host-ca-gateway.tf
+++ b/modules/baseline/host-ca-gateway.tf
@@ -200,6 +200,7 @@ module "ma_system_status_check_ca_gateway" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -208,7 +209,7 @@ module "ma_system_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_ca_gateway" {
@@ -218,6 +219,7 @@ module "ma_instance_status_check_ca_gateway" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -226,7 +228,7 @@ module "ma_instance_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_ca_gateway" {
@@ -236,6 +238,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 15
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -244,7 +247,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_ca_gateway" {
@@ -254,6 +257,7 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 1500
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -262,5 +266,5 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline/host-ca-gateway.tf
+++ b/modules/baseline/host-ca-gateway.tf
@@ -209,7 +209,7 @@ module "ma_system_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_ca_gateway" {
@@ -228,7 +228,7 @@ module "ma_instance_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_ca_gateway" {
@@ -247,7 +247,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_ca_gateway" {
@@ -266,5 +266,5 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline/host-issuing-ca.tf
+++ b/modules/baseline/host-issuing-ca.tf
@@ -372,6 +372,7 @@ module "ma_system_status_check_issuing_ca" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -380,7 +381,7 @@ module "ma_system_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_issuing_ca" {
@@ -390,15 +391,16 @@ module "ma_instance_status_check_issuing_ca" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
-  period              = 60
+  period              = 10
   unit                = "Count"
 
   metric_name = "StatusCheckFailed_Instance"
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_issuing_ca" {
@@ -408,6 +410,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 20
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -416,7 +419,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_issuing_ca" {
@@ -426,6 +429,7 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 2500
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -434,5 +438,5 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline/host-issuing-ca.tf
+++ b/modules/baseline/host-issuing-ca.tf
@@ -381,7 +381,7 @@ module "ma_system_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_issuing_ca" {
@@ -400,7 +400,7 @@ module "ma_instance_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_issuing_ca" {
@@ -419,7 +419,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_issuing_ca" {
@@ -438,5 +438,5 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline/host-ra-app-server.tf
+++ b/modules/baseline/host-ra-app-server.tf
@@ -246,7 +246,7 @@ module "ma_system_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_ra_app_server" {
@@ -265,7 +265,7 @@ module "ma_instance_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_ra_app_server" {
@@ -284,7 +284,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_ra_app_server" {
@@ -303,5 +303,5 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline/host-ra-app-server.tf
+++ b/modules/baseline/host-ra-app-server.tf
@@ -237,6 +237,7 @@ module "ma_system_status_check_ra_app_server" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -245,7 +246,7 @@ module "ma_system_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_ra_app_server" {
@@ -255,6 +256,7 @@ module "ma_instance_status_check_ra_app_server" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -263,7 +265,7 @@ module "ma_instance_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_ra_app_server" {
@@ -273,6 +275,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 18
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -281,7 +284,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_ra_app_server" {
@@ -291,6 +294,7 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 3500
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -299,5 +303,5 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline/host-ra-web-server.tf
+++ b/modules/baseline/host-ra-web-server.tf
@@ -209,7 +209,7 @@ module "ma_system_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_ra_web_server" {
@@ -228,7 +228,7 @@ module "ma_instance_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_ra_web_server" {
@@ -247,7 +247,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_ra_web_server" {
@@ -266,5 +266,5 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline/host-ra-web-server.tf
+++ b/modules/baseline/host-ra-web-server.tf
@@ -200,6 +200,7 @@ module "ma_system_status_check_ra_web_server" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -208,7 +209,7 @@ module "ma_system_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_ra_web_server" {
@@ -218,6 +219,7 @@ module "ma_instance_status_check_ra_web_server" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -226,7 +228,7 @@ module "ma_instance_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_ra_web_server" {
@@ -236,6 +238,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 1
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -244,7 +247,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_ra_web_server" {
@@ -254,6 +257,7 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 3000
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -262,5 +266,5 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline/locals.tf
+++ b/modules/baseline/locals.tf
@@ -62,4 +62,5 @@ locals {
   cidr_private_b = "172.16.0.0/12"
   cidr_private_c = "192.168.0.0/16"
 
+  sns_topic_alarm_action = "arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"
 }

--- a/modules/baseline/main.tf
+++ b/modules/baseline/main.tf
@@ -4,6 +4,8 @@ terraform {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 module "pki_vpc" {
   source = ".././vpc"
 

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -211,7 +211,7 @@ module "ma_system_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_ca_gateway" {
@@ -230,7 +230,7 @@ module "ma_instance_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_ca_gateway" {
@@ -249,7 +249,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_ca_gateway" {
@@ -268,5 +268,5 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline_preprod/host-ca-gateway.tf
+++ b/modules/baseline_preprod/host-ca-gateway.tf
@@ -202,6 +202,7 @@ module "ma_system_status_check_ca_gateway" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -210,7 +211,7 @@ module "ma_system_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_ca_gateway" {
@@ -220,6 +221,7 @@ module "ma_instance_status_check_ca_gateway" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -228,7 +230,7 @@ module "ma_instance_status_check_ca_gateway" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_ca_gateway" {
@@ -238,6 +240,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 15
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -246,7 +249,7 @@ module "ma_cpu_utilization_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_ca_gateway" {
@@ -256,6 +259,7 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 1500
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -264,5 +268,5 @@ module "ma_network_packets_in_status_check_ca_gateway" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ca_gateway.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -374,6 +374,7 @@ module "ma_system_status_check_issuing_ca" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -382,7 +383,7 @@ module "ma_system_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_issuing_ca" {
@@ -392,6 +393,7 @@ module "ma_instance_status_check_issuing_ca" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -400,7 +402,7 @@ module "ma_instance_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_issuing_ca" {
@@ -410,6 +412,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 20
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -418,7 +421,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_issuing_ca" {
@@ -428,6 +431,7 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 2500
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -436,5 +440,5 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -383,7 +383,7 @@ module "ma_system_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_issuing_ca" {
@@ -402,7 +402,7 @@ module "ma_instance_status_check_issuing_ca" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_issuing_ca" {
@@ -421,7 +421,7 @@ module "ma_cpu_utilization_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_issuing_ca" {
@@ -440,5 +440,5 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   statistic   = "Average"
 
   instance_id   = module.ec2_issuing_ca.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -335,11 +335,11 @@ resource "aws_ebs_volume" "issuing_CA_secondary_ebs" {
   availability_zone = module.pki_vpc.private_subnet_backend_zone_az
   size              = 60
   tags = merge(
-    var.tags, tomap({
-      "Name" : "${var.prefix}-issuing-ca-dev-sdh",
-      "Environment" : var.environment_description,
-      "device_name" : "/dev/sdh"
-    })
+    var.tags, {
+      Name = "${var.prefix}-issuing-ca-dev-sdh",
+      Environment = var.environment_description,
+      device_name = "/dev/sdh"
+    }
   )
 }
 

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -336,7 +336,7 @@ resource "aws_ebs_volume" "issuing_CA_secondary_ebs" {
   size              = 60
   tags = merge(
     var.tags, {
-      Name = "${var.prefix}-issuing-ca-dev-sdh",
+      Name        = "${var.prefix}-issuing-ca-dev-sdh",
       Environment = var.environment_description,
       device_name = "/dev/sdh"
     }

--- a/modules/baseline_preprod/host-ra-app-server.tf
+++ b/modules/baseline_preprod/host-ra-app-server.tf
@@ -248,7 +248,7 @@ module "ma_system_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_ra_app_server" {
@@ -267,7 +267,7 @@ module "ma_instance_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_ra_app_server" {
@@ -286,7 +286,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_ra_app_server" {
@@ -305,5 +305,5 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline_preprod/host-ra-app-server.tf
+++ b/modules/baseline_preprod/host-ra-app-server.tf
@@ -239,6 +239,7 @@ module "ma_system_status_check_ra_app_server" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -247,7 +248,7 @@ module "ma_system_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_ra_app_server" {
@@ -257,6 +258,7 @@ module "ma_instance_status_check_ra_app_server" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -265,7 +267,7 @@ module "ma_instance_status_check_ra_app_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_ra_app_server" {
@@ -275,6 +277,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 18
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -283,7 +286,7 @@ module "ma_cpu_utilization_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_ra_app_server" {
@@ -293,6 +296,7 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 3500
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -301,5 +305,5 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_app_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline_preprod/host-ra-web-server.tf
+++ b/modules/baseline_preprod/host-ra-web-server.tf
@@ -202,6 +202,7 @@ module "ma_system_status_check_ra_web_server" {
   alarm_description   = "Check for system status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -210,7 +211,7 @@ module "ma_system_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_instance_status_check_ra_web_server" {
@@ -220,6 +221,7 @@ module "ma_instance_status_check_ra_web_server" {
   alarm_description   = "Check for instance status check errors."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
+  datapoints_to_alarm = 1
   threshold           = 1
   period              = 60
   unit                = "Count"
@@ -228,7 +230,7 @@ module "ma_instance_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_cpu_utilization_status_check_ra_web_server" {
@@ -238,6 +240,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   alarm_description   = "Alarm when CPU utilization is greater than or equal to 15%."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 1
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -246,7 +249,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }
 
 module "ma_network_packets_in_status_check_ra_web_server" {
@@ -256,6 +259,7 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   alarm_description   = "Alarm when incoming network packets is greater than or equal to 1500."
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
+  datapoints_to_alarm = 2
   threshold           = 3000
   period              = 300 # 5 minutes
   unit                = "Count"
@@ -264,5 +268,5 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = [var.sns_topic_arn]
+  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
 }

--- a/modules/baseline_preprod/host-ra-web-server.tf
+++ b/modules/baseline_preprod/host-ra-web-server.tf
@@ -211,7 +211,7 @@ module "ma_system_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_instance_status_check_ra_web_server" {
@@ -230,7 +230,7 @@ module "ma_instance_status_check_ra_web_server" {
   statistic   = "Maximum"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_cpu_utilization_status_check_ra_web_server" {
@@ -249,7 +249,7 @@ module "ma_cpu_utilization_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }
 
 module "ma_network_packets_in_status_check_ra_web_server" {
@@ -268,5 +268,5 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   statistic   = "Average"
 
   instance_id   = module.ec2_ra_web_server.instance_id[0]
-  alarm_actions = ["arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"]
+  alarm_actions = [local.sns_topic_alarm_action]
 }

--- a/modules/baseline_preprod/locals.tf
+++ b/modules/baseline_preprod/locals.tf
@@ -62,4 +62,6 @@ locals {
   cidr_private_b = "172.16.0.0/12"
   cidr_private_c = "192.168.0.0/16"
 
+  sns_topic_alarm_action = "arn:aws:sns:${var.region_id}:${data.aws_caller_identity.current.account_id}:ec2-alarm-sns"
+
 }

--- a/modules/baseline_preprod/main.tf
+++ b/modules/baseline_preprod/main.tf
@@ -4,6 +4,8 @@ terraform {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 module "pki_vpc" {
   source = ".././vpc"
 

--- a/modules/ec2alarms/main.tf
+++ b/modules/ec2alarms/main.tf
@@ -6,6 +6,7 @@ module "metric_alarm" {
   alarm_description   = var.alarm_description
   comparison_operator = var.comparison_operator
   evaluation_periods  = var.evaluation_periods
+  datapoints_to_alarm = var.datapoints_to_alarm
   threshold           = var.threshold
   period              = var.period
   unit                = var.unit

--- a/modules/ec2alarms/variables.tf
+++ b/modules/ec2alarms/variables.tf
@@ -18,6 +18,11 @@ variable "evaluation_periods" {
   type        = number
 }
 
+variable "datapoints_to_alarm" {
+  description = "The number of datapoints that must be breaching to trigger the alarm."
+  type        = number
+}
+
 variable "threshold" {
   description = "The value against which the specified statistic is compared."
   type        = number


### PR DESCRIPTION
* Manually create alarm actions arn - This is due to TF provider using `***` in place of account id causing permission issues.
* Align thresholds to production settings

This change in the plan only updates 5 resources, all of which are tags. The purpose of this was to ensure the TF code matches the production configuration and to make no changes.