### PR TITLE
Add VPN Tunnel defaults

### DIFF
--- a/modules/baseline/host-issuing-ca.tf
+++ b/modules/baseline/host-issuing-ca.tf
@@ -314,7 +314,22 @@ module "sg_issuing_ca" {
       description = "Allow issuing CA to HSM Secondary"
       cidr_blocks = local.ip_hsm_secondary
     },
-
+    # HSM LD6 London
+    {
+      from_port   = 1792
+      to_port     = 1792
+      protocol    = local.tcp_protocol
+      description = "Allow issuing CA to HSM LD6 London"
+      cidr_blocks = local.ip_hsm_ld6
+    },
+    # HSM TSC Newbury
+    {
+      from_port   = 1792
+      to_port     = 1792
+      protocol    = local.tcp_protocol
+      description = "Allow issuing CA to HSM TSC Newbury"
+      cidr_blocks = local.ip_hsm_tsc
+    },
   ]
 
   tags = var.tags

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -377,13 +377,6 @@ resource "aws_ebs_volume" "issuing_CA_tertiary_ebs" {
       "device_name" : "/dev/sdi"
     })
   )
-  tags_all = merge(
-    var.tags, tomap({
-      "Name" : "${var.prefix}-issuing-ca-dev-sdi",
-      "Environment" : var.environment_description,
-      "device_name" : "/dev/sdi"
-    })
-  )
 }
 
 resource "aws_volume_attachment" "issuing_CA_tertiary_ebs_attach" {

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -314,7 +314,22 @@ module "sg_issuing_ca" {
       description = "Allow issuing CA to HSM Secondary"
       cidr_blocks = local.ip_hsm_secondary
     },
-
+    # HSM LD6 London
+    {
+      from_port   = 1792
+      to_port     = 1792
+      protocol    = local.tcp_protocol
+      description = "Allow issuing CA to HSM LD6 London"
+      cidr_blocks = local.ip_hsm_ld6
+    },
+    # HSM TSC Newbury
+    {
+      from_port   = 1792
+      to_port     = 1792
+      protocol    = local.tcp_protocol
+      description = "Allow issuing CA to HSM TSC Newbury"
+      cidr_blocks = local.ip_hsm_tsc
+    },
   ]
 
   tags = var.tags

--- a/modules/baseline_preprod/host-issuing-ca.tf
+++ b/modules/baseline_preprod/host-issuing-ca.tf
@@ -377,6 +377,13 @@ resource "aws_ebs_volume" "issuing_CA_tertiary_ebs" {
       "device_name" : "/dev/sdi"
     })
   )
+  tags_all = merge(
+    var.tags, tomap({
+      "Name" : "${var.prefix}-issuing-ca-dev-sdi",
+      "Environment" : var.environment_description,
+      "device_name" : "/dev/sdi"
+    })
+  )
 }
 
 resource "aws_volume_attachment" "issuing_CA_tertiary_ebs_attach" {

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -65,14 +65,14 @@ resource "aws_vpn_connection" "vpn_ld6" {
   static_routes_only  = true
 
   tunnel1_phase1_encryption_algorithms = "AES256"
-  tunnel1_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
-  tunnel1_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel1_ike_versions = "ikev2"
+  tunnel1_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
+  tunnel1_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel1_ike_versions                 = "ikev2"
 
   tunnel2_phase1_encryption_algorithms = "AES256"
-  tunnel2_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
-  tunnel2_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel2_ike_versions = "ikev2"
+  tunnel2_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
+  tunnel2_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel2_ike_versions                 = "ikev2"
 }
 
 resource "aws_vpn_connection_route" "entrust_ld6" {
@@ -98,14 +98,14 @@ resource "aws_vpn_connection" "vpn_tsc" {
   static_routes_only  = true
 
   tunnel1_phase1_encryption_algorithms = "AES256"
-  tunnel1_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
-  tunnel1_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel1_ike_versions = "ikev2"
+  tunnel1_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
+  tunnel1_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel1_ike_versions                 = "ikev2"
 
   tunnel2_phase1_encryption_algorithms = "AES256"
-  tunnel2_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
-  tunnel2_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel2_ike_versions = "ikev2"
+  tunnel2_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
+  tunnel2_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel2_ike_versions                 = "ikev2"
 }
 
 resource "aws_vpn_connection_route" "entrust_tsc" {

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -68,11 +68,17 @@ resource "aws_vpn_connection" "vpn_ld6" {
   tunnel1_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
   tunnel1_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
   tunnel1_ike_versions                 = ["ikev2"]
+  tunnel1_phase2_encryption_algorithms = ["AES256"]
+  tunnel1_phase2_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel1_phase2_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
 
   tunnel2_phase1_encryption_algorithms = ["AES256"]
   tunnel2_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
   tunnel2_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
   tunnel2_ike_versions                 = ["ikev2"]
+  tunnel2_phase2_encryption_algorithms = ["AES256"]
+  tunnel2_phase2_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel2_phase2_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
 }
 
 resource "aws_vpn_connection_route" "entrust_ld6" {
@@ -101,11 +107,17 @@ resource "aws_vpn_connection" "vpn_tsc" {
   tunnel1_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
   tunnel1_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
   tunnel1_ike_versions                 = ["ikev2"]
+  tunnel1_phase2_encryption_algorithms = ["AES256"]
+  tunnel1_phase2_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel1_phase2_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
 
   tunnel2_phase1_encryption_algorithms = ["AES256"]
   tunnel2_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
   tunnel2_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
   tunnel2_ike_versions                 = ["ikev2"]
+  tunnel2_phase2_encryption_algorithms = ["AES256"]
+  tunnel2_phase2_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel2_phase2_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
 }
 
 resource "aws_vpn_connection_route" "entrust_tsc" {

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -64,15 +64,15 @@ resource "aws_vpn_connection" "vpn_ld6" {
   type                = "ipsec.1"
   static_routes_only  = true
 
-  tunnel1_phase1_encryption_algorithms = "AES256"
-  tunnel1_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
-  tunnel1_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel1_ike_versions                 = "ikev2"
+  tunnel1_phase1_encryption_algorithms = ["AES256"]
+  tunnel1_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel1_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
+  tunnel1_ike_versions                 = ["ikev2"]
 
-  tunnel2_phase1_encryption_algorithms = "AES256"
-  tunnel2_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
-  tunnel2_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel2_ike_versions                 = "ikev2"
+  tunnel2_phase1_encryption_algorithms = ["AES256"]
+  tunnel2_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel2_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
+  tunnel2_ike_versions                 = ["ikev2"]
 }
 
 resource "aws_vpn_connection_route" "entrust_ld6" {
@@ -97,15 +97,15 @@ resource "aws_vpn_connection" "vpn_tsc" {
   type                = "ipsec.1"
   static_routes_only  = true
 
-  tunnel1_phase1_encryption_algorithms = "AES256"
-  tunnel1_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
-  tunnel1_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel1_ike_versions                 = "ikev2"
+  tunnel1_phase1_encryption_algorithms = ["AES256"]
+  tunnel1_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel1_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
+  tunnel1_ike_versions                 = ["ikev2"]
 
-  tunnel2_phase1_encryption_algorithms = "AES256"
-  tunnel2_phase1_dh_group_numbers      = "20 | 21 | 22 | 23 | 24"
-  tunnel2_phase1_integrity_algorithms  = "SHA2-256 | SHA2-384 | SHA2-512"
-  tunnel2_ike_versions                 = "ikev2"
+  tunnel2_phase1_encryption_algorithms = ["AES256"]
+  tunnel2_phase1_dh_group_numbers      = ["20", "21", "22", "23", "24"]
+  tunnel2_phase1_integrity_algorithms  = ["SHA2-256", "SHA2-384", "SHA2-512"]
+  tunnel2_ike_versions                 = ["ikev2"]
 }
 
 resource "aws_vpn_connection_route" "entrust_tsc" {

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -63,6 +63,16 @@ resource "aws_vpn_connection" "vpn_ld6" {
   customer_gateway_id = var.cgw_hsm_ld6_id
   type                = "ipsec.1"
   static_routes_only  = true
+
+  tunnel1_phase1_encryption_algorithms = "AES256"
+  tunnel1_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
+  tunnel1_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel1_ike_versions = "ikev2"
+
+  tunnel2_phase1_encryption_algorithms = "AES256"
+  tunnel2_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
+  tunnel2_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel2_ike_versions = "ikev2"
 }
 
 resource "aws_vpn_connection_route" "entrust_ld6" {
@@ -86,6 +96,16 @@ resource "aws_vpn_connection" "vpn_tsc" {
   customer_gateway_id = var.cgw_hsm_tsc_id
   type                = "ipsec.1"
   static_routes_only  = true
+
+  tunnel1_phase1_encryption_algorithms = "AES256"
+  tunnel1_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
+  tunnel1_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel1_ike_versions = "ikev2"
+
+  tunnel2_phase1_encryption_algorithms = "AES256"
+  tunnel2_phase1_dh_group_numbers = "20 | 21 | 22 | 23 | 24"
+  tunnel2_phase1_integrity_algorithms = "SHA2-256 | SHA2-384 | SHA2-512"
+  tunnel2_ike_versions = "ikev2"
 }
 
 resource "aws_vpn_connection_route" "entrust_tsc" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.1.9"
+  required_version = "1.4.6"
 
   required_providers {
     aws = {


### PR DESCRIPTION
* Adds VPN Tunnel defaults
* Adds additional egress SG rules
* Bumps TF to a newer provider to reduce some plan tag output bugs. To fully remove others we need to upgrade to another major version

Plan: 12 to add, 5 to change, 8 to destroy.

8 to destroy are aws_routes and aws_vpn_connection_route where we have updated the secret value to match the actual value required. These are effectively replaces

5 to change are the standard tag outputs.

4 to add (minus above 8) are the egress SG rules