### PR TITLE
Adjust network packets in alarms threshold

### DIFF
--- a/modules/baseline/host-issuing-ca.tf
+++ b/modules/baseline/host-issuing-ca.tf
@@ -463,7 +463,7 @@ module "ma_network_packets_in_status_check_issuing_ca" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   datapoints_to_alarm = 2
-  threshold           = 2500
+  threshold           = 3500
   period              = 300 # 5 minutes
   unit                = "Count"
 

--- a/modules/baseline/host-ra-app-server.tf
+++ b/modules/baseline/host-ra-app-server.tf
@@ -295,7 +295,7 @@ module "ma_network_packets_in_status_check_ra_app_server" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   datapoints_to_alarm = 2
-  threshold           = 3500
+  threshold           = 15000
   period              = 300 # 5 minutes
   unit                = "Count"
 

--- a/modules/baseline/host-ra-web-server.tf
+++ b/modules/baseline/host-ra-web-server.tf
@@ -258,7 +258,7 @@ module "ma_network_packets_in_status_check_ra_web_server" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   datapoints_to_alarm = 2
-  threshold           = 3000
+  threshold           = 13000
   period              = 300 # 5 minutes
   unit                = "Count"
 


### PR DESCRIPTION
Change the Network Packets in alarm threshold to reduce noise and false positives in reporting.